### PR TITLE
Minor bug fixes in endpoint "worker-licence-applications"

### DIFF
--- a/src/Spd.Manager.Licence/SecurityWorkerAppManager.cs
+++ b/src/Spd.Manager.Licence/SecurityWorkerAppManager.cs
@@ -594,8 +594,8 @@ internal partial class SecurityWorkerAppManager :
         {
             if (!LicenceAppDocumentManager.WorkerCategoryTypeCode_NoNeedDocument.Contains(code))
             {
-                if (!newFileInfos.Any(f => Mappings.GetDocumentType1Enum(f.LicenceDocumentTypeCode) == Enum.Parse<DocumentTypeEnum>(code.ToString()))
-                    && !existingFileInfos.Any(f => Mappings.GetDocumentType1Enum(f.LicenceDocumentTypeCode) == Enum.Parse<DocumentTypeEnum>(code.ToString())))
+                if (!newFileInfos.Any(f => Mappings.GetDocumentType2Enum(f.LicenceDocumentTypeCode) == Enum.Parse<DocumentTypeEnum>(code.ToString()))
+                    && !existingFileInfos.Any(f => Mappings.GetDocumentType2Enum(f.LicenceDocumentTypeCode) == Enum.Parse<DocumentTypeEnum>(code.ToString())))
                 {
                     throw new ApiException(HttpStatusCode.BadRequest, $"Missing file for {code}");
                 }


### PR DESCRIPTION
Minor fixes done in endpoint: `/worker-licence-applications` which consider:

- Exclude null licence document type code from response, to avoid inconsistency in documents returned in `get` service
- Adjust dictionary used to validate document type in `post` service
