### PR TITLE
add protection code for inactive contact login

### DIFF
--- a/src/Spd.Manager.Licence/ApplicantProfileManager.cs
+++ b/src/Spd.Manager.Licence/ApplicantProfileManager.cs
@@ -78,11 +78,22 @@ namespace Spd.Manager.Licence
                 Identity? id = result.Items.FirstOrDefault();
                 if (id?.ContactId != null)
                 {
-                    //contact exists
-                    UpdateContactCmd updateContactCmd = _mapper.Map<UpdateContactCmd>(cmd);
-                    updateContactCmd.Id = (Guid)id.ContactId;
-                    updateContactCmd.IdentityId = id.Id;
-                    contactResp = await _contactRepository.ManageAsync(updateContactCmd, ct);
+                    contactResp = await _contactRepository.GetAsync((Guid)id.ContactId, ct);
+                    if (contactResp == null || !contactResp.IsActive)
+                    {
+                        //there is identity, but no contact
+                        CreateContactCmd createContactCmd = _mapper.Map<CreateContactCmd>(cmd);
+                        createContactCmd.IdentityId = id.Id;
+                        contactResp = await _contactRepository.ManageAsync(createContactCmd, ct);
+                    }
+                    else
+                    {
+                        //contact exists
+                        UpdateContactCmd updateContactCmd = _mapper.Map<UpdateContactCmd>(cmd);
+                        updateContactCmd.Id = (Guid)id.ContactId;
+                        updateContactCmd.IdentityId = id.Id;
+                        contactResp = await _contactRepository.ManageAsync(updateContactCmd, ct);
+                    }
                 }
                 else
                 {

--- a/src/Spd.Resource.Repository/Contact/Contract.cs
+++ b/src/Spd.Resource.Repository/Contact/Contract.cs
@@ -41,6 +41,7 @@ namespace Spd.Resource.Repository.Contact
         public DateTime? LastestScreeningLogin { get; set; }
         public DateTimeOffset? LicensingTermAgreedDateTime { get; set; }
         public IEnumerable<LicenceInfo> LicenceInfos { get; set; } = [];
+        public bool IsActive { get; set; } = true;
     }
     public record LicenceInfo
     {

--- a/src/Spd.Resource.Repository/Contact/Mappings.cs
+++ b/src/Spd.Resource.Repository/Contact/Mappings.cs
@@ -29,7 +29,8 @@ namespace Spd.Resource.Repository.Contact
             .ForMember(d => d.PoliceOfficerRoleCode, opt => opt.MapFrom(s => SharedMappingFuncs.GetPoliceRoleEnum(s.spd_peaceofficerstatus)))
             .ForMember(d => d.IsTreatedForMHC, opt => opt.MapFrom(s => SharedMappingFuncs.GetBool(s.spd_mentalhealthcondition)))
             .ForMember(d => d.LicensingTermAgreedDateTime, opt => opt.MapFrom(s => s.spd_lastloggedinlicensingportal))
-            .ForMember(d => d.LastestScreeningLogin, opt => opt.MapFrom(s => s.spd_lastloggedinscreeningportal));
+            .ForMember(d => d.LastestScreeningLogin, opt => opt.MapFrom(s => s.spd_lastloggedinscreeningportal))
+            .ForMember(d => d.IsActive, opt => opt.MapFrom(s => s.statecode == DynamicsConstants.StateCode_Active));
 
             _ = CreateMap<ContactCmd, contact>()
             .ForMember(d => d.firstname, opt => opt.MapFrom(s => StringHelper.ToTitleCase(s.FirstName)))


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- spdbt-2500 (When identity exists, contact cannot be found or inactive, make it as firsttime login. Protection codes needed.)
