### PR TITLE
fix GetAsync for licence and licenceApp

### DIFF
--- a/src/Spd.Resource.Repository/Licence/LicenceRepository.cs
+++ b/src/Spd.Resource.Repository/Licence/LicenceRepository.cs
@@ -21,7 +21,6 @@ internal class LicenceRepository : ILicenceRepository
             .Expand(i => i.spd_LicenceHolder_contact)
             .Expand(i => i.spd_LicenceHolder_account)
             .Expand(i => i.spd_CaseId)
-            .Where(l => l.statecode != DynamicsConstants.StateCode_Inactive)
             .Where(l => l.spd_licenceid == licenceId)
             .FirstOrDefaultAsync(ct);
 
@@ -42,6 +41,7 @@ internal class LicenceRepository : ILicenceRepository
             .Expand(i => i.spd_LicenceHolder_contact)
             .Expand(i => i.spd_LicenceHolder_account)
             .Expand(i => i.spd_CaseId);
+
         if (!qry.IncludeInactive)
             lics = lics.Where(d => d.statecode != DynamicsConstants.StateCode_Inactive);
 

--- a/src/Spd.Resource.Repository/LicenceApplication/LicenceApplicationRepository.cs
+++ b/src/Spd.Resource.Repository/LicenceApplication/LicenceApplicationRepository.cs
@@ -136,7 +136,6 @@ internal class LicenceApplicationRepository : ILicenceApplicationRepository
             .Expand(a => a.spd_application_spd_licencecategory)
             .Expand(a => a.spd_CurrentExpiredLicenceId)
             .Where(a => a.spd_applicationid == licenceApplicationId)
-            .Where(a => a.statecode != DynamicsConstants.StateCode_Inactive)
             .SingleOrDefaultAsync(ct);
         if (app == null)
             throw new ArgumentException("invalid app id");


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

-all Repo layer GetAsync,  we should not add inactive filter. The inactive in dynamics does not mean it is deleted. There are other meanings like expired, case generated etc. And we needs those inactive record info quite often. So, for GetAsync, no matter it is active or not, we need to return it to Manager layer. Manager can decide we throw exception or return depending on the current business scenario.
