### PR TITLE
return latest expired or valid licence

### DIFF
--- a/src/Spd.Manager.Licence/LicenceContract.cs
+++ b/src/Spd.Manager.Licence/LicenceContract.cs
@@ -40,7 +40,7 @@ public record LicenceResponse : LicenceBasicResponse
     public IEnumerable<Document> RationalDocumentInfos { get; set; } = [];
 };
 
-public record LicenceQuery(string? LicenceNumber, string? AccessCode, bool isLatestInactive = true) : IRequest<LicenceResponse>;
+public record LicenceQuery(string? LicenceNumber, string? AccessCode) : IRequest<LicenceResponse>;
 public record LicenceByIdQuery(Guid LicenceId) : IRequest<LicenceResponse>;
 public record LicenceListQuery(Guid? ApplicantId, Guid? BizId) : IRequest<IEnumerable<LicenceBasicResponse>>;
 public record LicencePhotoQuery(Guid LicenceId) : IRequest<FileResponse>;

--- a/src/Spd.Manager.Licence/LicenceManager.cs
+++ b/src/Spd.Manager.Licence/LicenceManager.cs
@@ -52,7 +52,7 @@ internal class LicenceManager :
                 {
                     LicenceNumber = query.LicenceNumber,
                     AccessCode = query.AccessCode,
-                    IncludeInactive = query.isLatestInactive,
+                    IncludeInactive = true,
                 }, cancellationToken);
 
         if (!response.Items.Any())

--- a/src/Spd.Presentation.Licensing/Controllers/LicenceController.cs
+++ b/src/Spd.Presentation.Licensing/Controllers/LicenceController.cs
@@ -56,10 +56,9 @@ namespace Spd.Presentation.Licensing.Controllers
         }
 
         /// <summary>
-        /// Get licence by licence number.
-        /// If isLatestInactive = true, it means return the latest inactive licence. If isLatestInactive=false, it will return the active licence.
+        /// Get latest licence by licence number.
         /// There should be only one active licence for each licenceNumber.
-        /// Example: http://localhost:5114/api/licence-lookup/TEST-02?accessCode=TEST&isLatestInactive=false
+        /// Example: http://localhost:5114/api/licence-lookup/TEST-02?accessCode=TEST
         /// </summary>
         /// <param name="licenceNumber"></param>
         /// <param name="accessCode"></param>
@@ -67,9 +66,9 @@ namespace Spd.Presentation.Licensing.Controllers
         [Route("api/licence-lookup/{licenceNumber}")]
         [HttpGet]
         [Authorize(Policy = "BcscBCeID")]
-        public async Task<LicenceResponse?> GetLicenceLookup([FromRoute][Required] string licenceNumber, [FromQuery] string? accessCode = null, [FromQuery] bool isLatestInactive = true)
+        public async Task<LicenceResponse?> GetLicenceLookup([FromRoute][Required] string licenceNumber, [FromQuery] string? accessCode = null)
         {
-            return await _mediator.Send(new LicenceQuery(licenceNumber, accessCode, isLatestInactive));
+            return await _mediator.Send(new LicenceQuery(licenceNumber, accessCode));
         }
 
         /// <summary>
@@ -90,7 +89,7 @@ namespace Spd.Presentation.Licensing.Controllers
         {
             await VerifyGoogleRecaptchaAsync(recaptcha, ct);
 
-            LicenceResponse response = await _mediator.Send(new LicenceQuery(licenceNumber, accessCode, isLatestInactive));
+            LicenceResponse response = await _mediator.Send(new LicenceQuery(licenceNumber, accessCode));
             Guid latestAppId;
             if (response.WorkerLicenceTypeCode == WorkerLicenceTypeCode.SecurityWorkerLicence)
                 latestAppId = await _mediator.Send(new GetLatestWorkerLicenceApplicationIdQuery((Guid)response.LicenceHolderId));

--- a/src/Spd.Resource.Repository/Licence/LicenceRepository.cs
+++ b/src/Spd.Resource.Repository/Licence/LicenceRepository.cs
@@ -54,6 +54,9 @@ internal class LicenceRepository : ILicenceRepository
         if (!qry.IncludeInactive)
             lics = lics.Where(d => d.statecode != DynamicsConstants.StateCode_Inactive);
 
+        if (qry.IncludeInactive)
+            lics = lics.Where(d => d.statuscode != (int)LicenceStatusOptionSet.Inactive && d.statuscode != (int)LicenceStatusOptionSet.Suspended);
+
         if (qry.LicenceId != null)
         {
             lics = lics.Where(a => a.spd_licenceid == qry.LicenceId);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- When user do search licence for licence number, we just return the latest licence no matter it is expired or valid. (but not suspended or inactive status)
