### PR TITLE
fix empty user email for screening

### DIFF
--- a/src/Spd.Manager.Screening/OrgUserManager.cs
+++ b/src/Spd.Manager.Screening/OrgUserManager.cs
@@ -66,7 +66,7 @@ namespace Spd.Manager.Screening
 
             //check email rule
             if (existingUsersResult.UserResults.Any(u =>
-                u.Email.Equals(request.OrgUserUpdateRequest.Email, StringComparison.InvariantCultureIgnoreCase) &&
+                u.Email != null && u.Email.Equals(request.OrgUserUpdateRequest.Email, StringComparison.InvariantCultureIgnoreCase) &&
                 u.Id != request.OrgUserUpdateRequest.Id))
             {
                 throw new DuplicateException(HttpStatusCode.BadRequest, $"This email '{request.OrgUserUpdateRequest.Email}' has been used by another user.");


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- existing user for screening does not have email, we need to add null check or exception will be thrown
