### PR TITLE
Emad/[SPDBT-2961] controlling member auth save

### DIFF
--- a/src/Spd.Manager.Licence.UnitTest/ControllingMemberCrcAppManagerTest.cs
+++ b/src/Spd.Manager.Licence.UnitTest/ControllingMemberCrcAppManagerTest.cs
@@ -71,7 +71,7 @@ public class ControllingMemberCrcAppManagerTests
         };
         
 
-        var command = new ControllingMemberCrcAppSubmitRequestCommand(request,
+        var command = new ControllingMemberCrcAppNewCommand(request,
             new List<LicAppFileInfo>
                 {
                     new LicAppFileInfo { LicenceDocumentTypeCode = LicenceDocumentTypeCode.PoliceBackgroundLetterOfNoConflict },
@@ -128,7 +128,7 @@ public class ControllingMemberCrcAppManagerTests
         };
 
 
-        var command = new ControllingMemberCrcAppSubmitRequestCommand(request,
+        var command = new ControllingMemberCrcAppNewCommand(request,
             new List<LicAppFileInfo>
                 {
                     new LicAppFileInfo { LicenceDocumentTypeCode = LicenceDocumentTypeCode.PoliceBackgroundLetterOfNoConflict },

--- a/src/Spd.Manager.Licence/ControllingMemberCrcAppContract.cs
+++ b/src/Spd.Manager.Licence/ControllingMemberCrcAppContract.cs
@@ -10,6 +10,7 @@ namespace Spd.Manager.Licence;
 public interface IControllingMemberCrcAppManager
 {
     public Task<ControllingMemberCrcAppCommandResponse> Handle(ControllingMemberCrcAppNewCommand command, CancellationToken ct);
+    public Task<ControllingMemberCrcAppCommandResponse> Handle(ControllingMemberCrcUpsertCommand command, CancellationToken ct);
 }
 public record ControllingMemberCrcAppBase
 {
@@ -46,7 +47,7 @@ public record ControllingMemberCrcUpsertCommand(ControllingMemberCrcAppUpsertReq
 public record ControllingMemberCrcAppUpsertRequest : ControllingMemberCrcAppBase
 {
     public IEnumerable<Document>? DocumentInfos { get; set; }
-    public Guid? LicenceAppId { get; set; }
+    public Guid? ControllingMemberAppId { get; set; }
     public Guid ApplicantId { get; set; }
 };
 #endregion

--- a/src/Spd.Manager.Licence/ControllingMemberCrcAppContract.cs
+++ b/src/Spd.Manager.Licence/ControllingMemberCrcAppContract.cs
@@ -9,11 +9,10 @@ using System.Threading.Tasks;
 namespace Spd.Manager.Licence;
 public interface IControllingMemberCrcAppManager
 {
-    public Task<ControllingMemberCrcAppCommandResponse> Handle(ControllingMemberCrcAppSubmitRequestCommand command, CancellationToken ct);
+    public Task<ControllingMemberCrcAppCommandResponse> Handle(ControllingMemberCrcAppNewCommand command, CancellationToken ct);
 }
-public abstract record ControllingMemberCrcApp
+public record ControllingMemberCrcAppBase
 {
-    //public string? AccessCode { get; set; }
     public Guid? ParentBizLicApplicationId { get; set; }
     public string? GivenName { get; set; }
     public string? MiddleName1 { get; set; }
@@ -40,17 +39,29 @@ public abstract record ControllingMemberCrcApp
     public Address? ResidentialAddress { get; set; }
 }
 
-public record ControllingMemberCrcAppCommandResponse
+
+#region authenticated
+public record ControllingMemberCrcUpsertCommand(ControllingMemberCrcAppUpsertRequest ControllingMemberCrcAppUpsertRequest) : IRequest<ControllingMemberCrcAppCommandResponse>;
+
+public record ControllingMemberCrcAppUpsertRequest : ControllingMemberCrcAppBase
 {
-    public Guid ControllingMemberAppId { get; set; }
+    public IEnumerable<Document>? DocumentInfos { get; set; }
+    public Guid? LicenceAppId { get; set; }
+    public Guid ApplicantId { get; set; }
 };
-
-
-public record ControllingMemberCrcAppSubmitRequest : ControllingMemberCrcApp
+#endregion
+#region anonymous user
+public record ControllingMemberCrcAppSubmitRequest : ControllingMemberCrcAppBase
 {
     public IEnumerable<Guid>? DocumentKeyCodes { get; set; }
     public IEnumerable<DocumentExpiredInfo> DocumentExpiredInfos { get; set; } = Enumerable.Empty<DocumentExpiredInfo>();
 
 };
 
-public record ControllingMemberCrcAppSubmitRequestCommand(ControllingMemberCrcAppSubmitRequest ControllingMemberCrcAppSubmitRequest, IEnumerable<LicAppFileInfo> LicAppFileInfos) : IRequest<ControllingMemberCrcAppCommandResponse>;
+public record ControllingMemberCrcAppNewCommand(ControllingMemberCrcAppSubmitRequest ControllingMemberCrcAppSubmitRequest, IEnumerable<LicAppFileInfo> LicAppFileInfos) : IRequest<ControllingMemberCrcAppCommandResponse>;
+public record ControllingMemberCrcAppCommandResponse
+{
+    public Guid ControllingMemberAppId { get; set; }
+};
+
+#endregion

--- a/src/Spd.Manager.Licence/ControllingMemberCrcAppManager.cs
+++ b/src/Spd.Manager.Licence/ControllingMemberCrcAppManager.cs
@@ -89,7 +89,7 @@ internal class ControllingMemberCrcAppManager :
         //TODO: find the purpose, add related enums if needed (ask peggy)
         saveCmd.UploadedDocumentEnums = GetUploadedDocumentEnumsFromDocumentInfo((List<Document>?)cmd.ControllingMemberCrcAppUpsertRequest.DocumentInfos);
 
-        var response = await _controllingMemberCrcRepository.SaveLicenceApplicationAsync(saveCmd, ct);
+        var response = await _controllingMemberCrcRepository.SaveControllingMenberCrcApplicationAsync(saveCmd, ct);
         if (cmd.ControllingMemberCrcAppUpsertRequest.ControllingMemberAppId == null)
             cmd.ControllingMemberCrcAppUpsertRequest.ControllingMemberAppId = response.ControllingMemberCrcAppId;
         await UpdateDocumentsAsync(

--- a/src/Spd.Manager.Licence/ControllingMemberCrcAppManager.cs
+++ b/src/Spd.Manager.Licence/ControllingMemberCrcAppManager.cs
@@ -71,8 +71,8 @@ internal class ControllingMemberCrcAppManager :
         
         //TODO: find the purpose, add related enums if needed (ask peggy)
         saveCmd.UploadedDocumentEnums = GetUploadedDocumentEnumsFromDocumentInfo((List<Document>?)cmd.ControllingMemberCrcAppUpsertRequest.DocumentInfos);
-
-        var response = await _controllingMemberCrcRepository.SaveControllingMenberCrcApplicationAsync(saveCmd, ct);
+        saveCmd.WorkerLicenceTypeCode = WorkerLicenceTypeEnum.SECURITY_BUSINESS_LICENCE_CONTROLLING_MEMBER_CRC;
+        var response = await _controllingMemberCrcRepository.SaveControllingMemberCrcApplicationAsync(saveCmd, ct);
         if (cmd.ControllingMemberCrcAppUpsertRequest.ControllingMemberAppId == null)
             cmd.ControllingMemberCrcAppUpsertRequest.ControllingMemberAppId = response.ControllingMemberCrcAppId;
         await UpdateDocumentsAsync(

--- a/src/Spd.Manager.Licence/ControllingMemberCrcAppManager.cs
+++ b/src/Spd.Manager.Licence/ControllingMemberCrcAppManager.cs
@@ -67,23 +67,6 @@ internal class ControllingMemberCrcAppManager :
     #endregion
     public async Task<ControllingMemberCrcAppCommandResponse> Handle(ControllingMemberCrcUpsertCommand cmd, CancellationToken ct)
     {
-        /*duplication check for crc apps? is there any posibility that someone be the member of two businesses, and done criminal record check once, so is that valid for another business
-
-        we need to check that ? or even it can  filtered by business before sending the link to its members ?
-
-
-       bool hasDuplicate = await HasDuplicates(cmd.ControllingMemberCrcAppUpsertRequest.ApplicantId,
-           Enum.Parse<WorkerLicenceTypeEnum>(cmd.ControllingMemberCrcAppUpsertRequest.WorkerLicenceTypeCode.ToString()),
-           cmd.ControllingMemberCrcAppUpsertRequest.LicenceAppId,
-           ct);
-
-        if (hasDuplicate)
-        {
-            throw new ApiException(HttpStatusCode.Forbidden, "Applicant already has the same kind of licence or licence application");
-        }
-        */
-
-        //TODO: check and add mappings
         SaveControllingMemberCrcAppCmd saveCmd = _mapper.Map<SaveControllingMemberCrcAppCmd>(cmd.ControllingMemberCrcAppUpsertRequest);
         
         //TODO: find the purpose, add related enums if needed (ask peggy)

--- a/src/Spd.Manager.Licence/ControllingMemberCrcAppManager.cs
+++ b/src/Spd.Manager.Licence/ControllingMemberCrcAppManager.cs
@@ -20,7 +20,7 @@ using Spd.Resource.Repository.LicApp;
 namespace Spd.Manager.Licence;
 internal class ControllingMemberCrcAppManager : 
     LicenceAppManagerBase,
-    IRequestHandler<ControllingMemberCrcAppSubmitRequestCommand, ControllingMemberCrcAppCommandResponse>,
+    IRequestHandler<ControllingMemberCrcAppNewCommand, ControllingMemberCrcAppCommandResponse>,
     IControllingMemberCrcAppManager
 {
     private readonly IControllingMemberCrcRepository _controllingMemberCrcRepository;
@@ -43,7 +43,7 @@ internal class ControllingMemberCrcAppManager :
     {
         _controllingMemberCrcRepository = controllingMemberCrcRepository;
     }
-    public async Task<ControllingMemberCrcAppCommandResponse> Handle(ControllingMemberCrcAppSubmitRequestCommand cmd, CancellationToken ct)
+    public async Task<ControllingMemberCrcAppCommandResponse> Handle(ControllingMemberCrcAppNewCommand cmd, CancellationToken ct)
     {
 
         ControllingMemberCrcAppSubmitRequest request = cmd.ControllingMemberCrcAppSubmitRequest;
@@ -62,7 +62,7 @@ internal class ControllingMemberCrcAppManager :
             ControllingMemberAppId = response.ControllingMemberCrcAppId
         };
     }
-    private static void ValidateFilesForNewApp(ControllingMemberCrcAppSubmitRequestCommand cmd)
+    private static void ValidateFilesForNewApp(ControllingMemberCrcAppNewCommand cmd)
     {
         ControllingMemberCrcAppSubmitRequest request = cmd.ControllingMemberCrcAppSubmitRequest;
         IEnumerable<LicAppFileInfo> fileInfos = cmd.LicAppFileInfos;

--- a/src/Spd.Manager.Licence/Mappings.cs
+++ b/src/Spd.Manager.Licence/Mappings.cs
@@ -335,6 +335,17 @@ internal class Mappings : Profile
             .ForPath(d => d.ResidentialAddressData.City, opt => opt.MapFrom(s => s.ResidentialAddress.City))
             .ForPath(d => d.ResidentialAddressData.PostalCode, opt => opt.MapFrom(s => s.ResidentialAddress.PostalCode))
             .ForPath(d => d.ResidentialAddressData.Country, opt => opt.MapFrom(s => s.ResidentialAddress.Country));
+
+        CreateMap<ControllingMemberCrcAppUpsertRequest, SaveControllingMemberCrcAppCmd>()
+            .ForPath(d => d.ResidentialAddressData.AddressLine1, opt => opt.MapFrom(s => s.ResidentialAddress.AddressLine1))
+            .ForPath(d => d.ResidentialAddressData.AddressLine2, opt => opt.MapFrom(s => s.ResidentialAddress.AddressLine2))
+            .ForPath(d => d.ResidentialAddressData.Province, opt => opt.MapFrom(s => s.ResidentialAddress.Province))
+            .ForPath(d => d.ResidentialAddressData.City, opt => opt.MapFrom(s => s.ResidentialAddress.City))
+            .ForPath(d => d.ResidentialAddressData.PostalCode, opt => opt.MapFrom(s => s.ResidentialAddress.PostalCode))
+            .ForPath(d => d.ResidentialAddressData.Country, opt => opt.MapFrom(s => s.ResidentialAddress.Country));
+
+        CreateMap<ControllingMemberCrcApplicationCmdResp, ControllingMemberCrcAppCommandResponse>();
+
     }
 
     private static WorkerCategoryTypeEnum[] GetCategories(IEnumerable<WorkerCategoryTypeCode> codes)

--- a/src/Spd.Presentation.Licensing/Controllers/ControllingMemberCrcAppController.cs
+++ b/src/Spd.Presentation.Licensing/Controllers/ControllingMemberCrcAppController.cs
@@ -43,7 +43,7 @@ public class ControllingMemberCrcAppController : SpdLicenceControllerBase
     /// </summary>
     /// <param name="controllingMemberCrcAppUpsertRequest"></param>
     /// <returns></returns>
-    [Route("api/permit-applications")]
+    [Route("api/controlling-member-crc-applications")]
     [Authorize(Policy = "OnlyBcsc")]
     [HttpPost]
     public async Task<ControllingMemberCrcAppCommandResponse> SaveControllingMemberCrcApplication([FromBody][Required] ControllingMemberCrcAppUpsertRequest controllingMemberCrcAppUpsertRequest)

--- a/src/Spd.Presentation.Licensing/Controllers/ControllingMemberCrcAppController.cs
+++ b/src/Spd.Presentation.Licensing/Controllers/ControllingMemberCrcAppController.cs
@@ -36,7 +36,25 @@ public class ControllingMemberCrcAppController : SpdLicenceControllerBase
         _configuration = configuration;
         _controllingMemberCrcAppSubmitValidator = controllingMemberCrcAppSubmitValidator;
     }
+    #region authenticated
 
+    /// <summary>
+    /// Create Controlling member CRC Application
+    /// </summary>
+    /// <param name="controllingMemberCrcAppUpsertRequest"></param>
+    /// <returns></returns>
+    [Route("api/permit-applications")]
+    [Authorize(Policy = "OnlyBcsc")]
+    [HttpPost]
+    public async Task<ControllingMemberCrcAppCommandResponse> SaveControllingMemberCrcApplication([FromBody][Required] ControllingMemberCrcAppUpsertRequest controllingMemberCrcAppUpsertRequest)
+    {
+        if (controllingMemberCrcAppUpsertRequest.ApplicantId == Guid.Empty)
+            throw new ApiException(HttpStatusCode.BadRequest, "must have applicant");
+        return await _mediator.Send(new ControllingMemberCrcUpsertCommand(controllingMemberCrcAppUpsertRequest));
+    }
+
+    #endregion authenticated
+    #region anonymous
     /// <summary>
     /// Upload licence application first step: frontend needs to make this first request to get a Guid code.
     /// the keycode will be set in the cookies
@@ -91,7 +109,8 @@ public class ControllingMemberCrcAppController : SpdLicenceControllerBase
             throw new ApiException(HttpStatusCode.BadRequest, JsonSerializer.Serialize(validateResult.Errors));
 
         ControllingMemberCrcAppCommandResponse? response = null;
-        response = await _mediator.Send(new ControllingMemberCrcAppSubmitRequestCommand(ControllingMemberCrcSubmitRequest, newDocInfos), ct);
+        response = await _mediator.Send(new ControllingMemberCrcAppNewCommand(ControllingMemberCrcSubmitRequest, newDocInfos), ct);
         return response;
     }
+    #endregion anonymous
 }

--- a/src/Spd.Resource.Repository/ControllingMemberCrcApplication/Contract.cs
+++ b/src/Spd.Resource.Repository/ControllingMemberCrcApplication/Contract.cs
@@ -12,11 +12,13 @@ namespace Spd.Resource.Repository.ControllingMemberCrcApplication;
 public partial interface IControllingMemberCrcRepository
 {
     public Task<ControllingMemberCrcApplicationCmdResp> CreateControllingMemberCrcApplicationAsync(CreateControllingMemberCrcAppCmd cmd, CancellationToken ct);
-    public Task<ControllingMemberCrcApplicationResp> SaveLicenceApplicationAsync(SaveControllingMemberCrcAppCmd saveCmd, CancellationToken ct);
+    public Task<ControllingMemberCrcApplicationCmdResp> SaveControllingMenberCrcApplicationAsync(SaveControllingMemberCrcAppCmd saveCmd, CancellationToken ct);
 }
 
 public record ControllingMemberCrcApplication
 {
+    public WorkerLicenceTypeEnum WorkerLicenceTypeCode { get; set; }
+    public ApplicationTypeEnum ApplicationTypeCode { get; set; }
     public Guid? ParentBizLicApplicationId { get; set; }
     public string? GivenName { get; set; }
     public string? MiddleName1 { get; set; }

--- a/src/Spd.Resource.Repository/ControllingMemberCrcApplication/Contract.cs
+++ b/src/Spd.Resource.Repository/ControllingMemberCrcApplication/Contract.cs
@@ -12,7 +12,7 @@ namespace Spd.Resource.Repository.ControllingMemberCrcApplication;
 public partial interface IControllingMemberCrcRepository
 {
     public Task<ControllingMemberCrcApplicationCmdResp> CreateControllingMemberCrcApplicationAsync(CreateControllingMemberCrcAppCmd cmd, CancellationToken ct);
-    public Task<ControllingMemberCrcApplicationCmdResp> SaveControllingMenberCrcApplicationAsync(SaveControllingMemberCrcAppCmd saveCmd, CancellationToken ct);
+    public Task<ControllingMemberCrcApplicationCmdResp> SaveControllingMemberCrcApplicationAsync(SaveControllingMemberCrcAppCmd saveCmd, CancellationToken ct);
 }
 
 public record ControllingMemberCrcApplication

--- a/src/Spd.Resource.Repository/ControllingMemberCrcApplication/Contract.cs
+++ b/src/Spd.Resource.Repository/ControllingMemberCrcApplication/Contract.cs
@@ -12,8 +12,10 @@ namespace Spd.Resource.Repository.ControllingMemberCrcApplication;
 public partial interface IControllingMemberCrcRepository
 {
     public Task<ControllingMemberCrcApplicationCmdResp> CreateControllingMemberCrcApplicationAsync(CreateControllingMemberCrcAppCmd cmd, CancellationToken ct);
+    public Task<ControllingMemberCrcApplicationResp> SaveLicenceApplicationAsync(SaveControllingMemberCrcAppCmd saveCmd, CancellationToken ct);
 }
-    public record ControllingMemberCrcApplication
+
+public record ControllingMemberCrcApplication
 {
     public Guid? ParentBizLicApplicationId { get; set; }
     public string? GivenName { get; set; }
@@ -41,20 +43,20 @@ public partial interface IControllingMemberCrcRepository
     public ResidentialAddr? ResidentialAddressData { get; set; }
     public IEnumerable<UploadedDocumentEnum>? UploadedDocumentEnums { get; set; }
 }
-
 public record CreateControllingMemberCrcAppCmd() : ControllingMemberCrcApplication
 {
-
+    public ApplicationStatusEnum ApplicationStatusEnum { get; set; } = ApplicationStatusEnum.Incomplete;
 };
+public record SaveControllingMemberCrcAppCmd() : ControllingMemberCrcApplication
+{
+    public Guid? ControllingMemberCrcAppId { get; set; }
+    public Guid ContactId { get; set; }
+    public ApplicationStatusEnum ApplicationStatusEnum { get; set; } = ApplicationStatusEnum.Incomplete;
+}
 public record ControllingMemberCrcApplicationResp() : ControllingMemberCrcApplication
 {
     //TODO: what are response props?
     public Guid? ControllingMemberCrcAppId { get; set; }
     public Guid? ContactId { get; set; }
-    //public DateOnly? ExpiryDate { get; set; }
-    //public ApplicationPortalStatusEnum? ApplicationPortalStatus { get; set; }
-    //public string? CaseNumber { get; set; }
-    //public LicenceTermEnum? OriginalLicenceTermCode { get; set; }
-    //public string? ExpiredLicenceNumber { get; set; }
 }
 public record ControllingMemberCrcApplicationCmdResp(Guid ControllingMemberCrcAppId, Guid? ContactId = null);

--- a/src/Spd.Resource.Repository/ControllingMemberCrcApplication/ControllingMemberCrcRepository.cs
+++ b/src/Spd.Resource.Repository/ControllingMemberCrcApplication/ControllingMemberCrcRepository.cs
@@ -63,4 +63,8 @@ public class ControllingMemberCrcRepository : IControllingMemberCrcRepository
         return new ControllingMemberCrcApplicationCmdResp((Guid)app.spd_applicationid, (Guid) contact.contactid);
     }
 
+    public async Task<ControllingMemberCrcApplicationResp> SaveLicenceApplicationAsync(SaveControllingMemberCrcAppCmd saveCmd, CancellationToken ct)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/Spd.Resource.Repository/ControllingMemberCrcApplication/ControllingMemberCrcRepository.cs
+++ b/src/Spd.Resource.Repository/ControllingMemberCrcApplication/ControllingMemberCrcRepository.cs
@@ -64,7 +64,7 @@ public class ControllingMemberCrcRepository : IControllingMemberCrcRepository
         return new ControllingMemberCrcApplicationCmdResp((Guid)app.spd_applicationid, (Guid) contact.contactid);
     }
 
-    public async Task<ControllingMemberCrcApplicationCmdResp> SaveControllingMenberCrcApplicationAsync(SaveControllingMemberCrcAppCmd cmd, CancellationToken ct)
+    public async Task<ControllingMemberCrcApplicationCmdResp> SaveControllingMemberCrcApplicationAsync(SaveControllingMemberCrcAppCmd cmd, CancellationToken ct)
     {
         spd_application? app;
         if (cmd.ControllingMemberCrcAppId != null)
@@ -88,24 +88,10 @@ public class ControllingMemberCrcRepository : IControllingMemberCrcRepository
                 _context.SetLink(app, nameof(spd_application.spd_ApplicantId_contact), contact);
             }
         }
-        //TODO: what is the LinkServiceType??
         SharedRepositoryFuncs.LinkServiceType(_context, cmd.WorkerLicenceTypeCode, app);
-   
-    
-        //TODO: what is the LinkTeam ??
-        await LinkTeam(DynamicsConstants.Licensing_Client_Service_Team_Guid, app, ct);
+        SharedRepositoryFuncs.LinkTeam(_context,DynamicsConstants.Licensing_Client_Service_Team_Guid, app);
         await _context.SaveChangesAsync();
-      
-
-        //TODO: do we have category codes in the crc controlling member process?
-        //SharedRepositoryFuncs.ProcessCategories(_context, cmd.CategoryCodes, app);
-        //await _context.SaveChangesAsync();
         return new ControllingMemberCrcApplicationCmdResp((Guid)app.spd_applicationid, (Guid)cmd.ContactId);
     }
-    private async Task LinkTeam(string teamGuidStr, spd_application app, CancellationToken ct)
-    {
-        Guid teamGuid = Guid.Parse(teamGuidStr);
-        team? serviceTeam = await _context.teams.Where(t => t.teamid == teamGuid).FirstOrDefaultAsync(ct);
-        _context.SetLink(app, nameof(spd_application.ownerid), serviceTeam);
-    }
+    
 }

--- a/src/Spd.Resource.Repository/ControllingMemberCrcApplication/ControllingMemberCrcRepository.cs
+++ b/src/Spd.Resource.Repository/ControllingMemberCrcApplication/ControllingMemberCrcRepository.cs
@@ -5,6 +5,7 @@ using Spd.Resource.Repository.Application;
 using Spd.Resource.Repository.BizLicApplication;
 using Spd.Resource.Repository.LicApp;
 using Spd.Resource.Repository.Org;
+using Spd.Resource.Repository.PersonLicApplication;
 using Spd.Utilities.Dynamics;
 using System;
 using System.Collections.Generic;
@@ -63,8 +64,48 @@ public class ControllingMemberCrcRepository : IControllingMemberCrcRepository
         return new ControllingMemberCrcApplicationCmdResp((Guid)app.spd_applicationid, (Guid) contact.contactid);
     }
 
-    public async Task<ControllingMemberCrcApplicationResp> SaveLicenceApplicationAsync(SaveControllingMemberCrcAppCmd saveCmd, CancellationToken ct)
+    public async Task<ControllingMemberCrcApplicationCmdResp> SaveControllingMenberCrcApplicationAsync(SaveControllingMemberCrcAppCmd cmd, CancellationToken ct)
     {
-        throw new NotImplementedException();
+        spd_application? app;
+        if (cmd.ControllingMemberCrcAppId != null)
+        {
+            app = _context.spd_applications
+                .Expand(a => a.spd_application_spd_licencecategory)
+                .Where(a => a.spd_applicationid == cmd.ControllingMemberCrcAppId).FirstOrDefault();
+            if (app == null)
+                throw new ArgumentException("invalid app id");
+            _mapper.Map<SaveControllingMemberCrcAppCmd, spd_application>(cmd, app);
+            app.spd_applicationid = (Guid)(cmd.ControllingMemberCrcAppId);
+            _context.UpdateObject(app);
+        }
+        else
+        {
+            app = _mapper.Map<spd_application>(cmd);
+            _context.AddTospd_applications(app);
+            var contact = _context.contacts.Where(l => l.contactid == cmd.ContactId).FirstOrDefault();
+            if (contact != null)
+            {
+                _context.SetLink(app, nameof(spd_application.spd_ApplicantId_contact), contact);
+            }
+        }
+        //TODO: what is the LinkServiceType??
+        SharedRepositoryFuncs.LinkServiceType(_context, cmd.WorkerLicenceTypeCode, app);
+   
+    
+        //TODO: what is the LinkTeam ??
+        await LinkTeam(DynamicsConstants.Licensing_Client_Service_Team_Guid, app, ct);
+        await _context.SaveChangesAsync();
+      
+
+        //TODO: do we have category codes in the crc controlling member process?
+        //SharedRepositoryFuncs.ProcessCategories(_context, cmd.CategoryCodes, app);
+        await _context.SaveChangesAsync();
+        return new ControllingMemberCrcApplicationCmdResp((Guid)app.spd_applicationid, (Guid)cmd.ContactId);
+    }
+    private async Task LinkTeam(string teamGuidStr, spd_application app, CancellationToken ct)
+    {
+        Guid teamGuid = Guid.Parse(teamGuidStr);
+        team? serviceTeam = await _context.teams.Where(t => t.teamid == teamGuid).FirstOrDefaultAsync(ct);
+        _context.SetLink(app, nameof(spd_application.ownerid), serviceTeam);
     }
 }

--- a/src/Spd.Resource.Repository/ControllingMemberCrcApplication/ControllingMemberCrcRepository.cs
+++ b/src/Spd.Resource.Repository/ControllingMemberCrcApplication/ControllingMemberCrcRepository.cs
@@ -99,7 +99,7 @@ public class ControllingMemberCrcRepository : IControllingMemberCrcRepository
 
         //TODO: do we have category codes in the crc controlling member process?
         //SharedRepositoryFuncs.ProcessCategories(_context, cmd.CategoryCodes, app);
-        await _context.SaveChangesAsync();
+        //await _context.SaveChangesAsync();
         return new ControllingMemberCrcApplicationCmdResp((Guid)app.spd_applicationid, (Guid)cmd.ContactId);
     }
     private async Task LinkTeam(string teamGuidStr, spd_application app, CancellationToken ct)

--- a/src/Spd.Resource.Repository/ControllingMemberCrcApplication/Mappings.cs
+++ b/src/Spd.Resource.Repository/ControllingMemberCrcApplication/Mappings.cs
@@ -61,6 +61,7 @@ internal class Mappings : Profile
 
         _ = CreateMap<ControllingMemberCrcApplication, spd_application>()
          .ForMember(d => d.spd_applicationid, opt => opt.MapFrom(s => Guid.NewGuid()))
+         .ForMember(d => d.spd_licenceapplicationtype, opt => opt.MapFrom(s => SharedMappingFuncs.GetLicenceApplicationTypeOptionSet(s.ApplicationTypeCode)))
          .ForMember(d => d.spd_firstname, opt => opt.MapFrom(s => s.GivenName))
          .ForMember(d => d.spd_lastname, opt => opt.MapFrom(s => s.Surname))
          .ForMember(d => d.spd_middlename1, opt => opt.MapFrom(s => s.MiddleName1))
@@ -103,6 +104,8 @@ internal class Mappings : Profile
          .ForMember(d => d.Surname, opt => opt.Ignore())
          .ForMember(d => d.MiddleName1, opt => opt.Ignore())
          .ForMember(d => d.MiddleName2, opt => opt.Ignore())
+         .ForMember(d => d.WorkerLicenceTypeCode, opt => opt.MapFrom(s => SharedMappingFuncs.GetServiceType(s._spd_servicetypeid_value)))
+         .ForMember(d => d.ApplicationTypeCode, opt => opt.MapFrom(s => SharedMappingFuncs.GetLicenceApplicationTypeEnum(s.spd_licenceapplicationtype)))
          .ForMember(d => d.DateOfBirth, opt => opt.Ignore())
          .ForMember(d => d.GenderCode, opt => opt.MapFrom(s => SharedMappingFuncs.GetGenderEnum(s.spd_sex)))
          .ForMember(d => d.HasCriminalHistory, opt => opt.MapFrom(s => SharedMappingFuncs.GetBool(s.spd_criminalhistory)))
@@ -124,6 +127,14 @@ internal class Mappings : Profile
           .ForMember(d => d.ContactId, opt => opt.MapFrom(s => s.spd_ApplicantId_contact.contactid))
           .ForMember(d => d.ControllingMemberCrcAppId, opt => opt.MapFrom(s => s.spd_applicationid))
           .IncludeBase<spd_application, ControllingMemberCrcApplication>();
+
+        _ = CreateMap<SaveControllingMemberCrcAppCmd, spd_application>()
+            .ForMember(d => d.statuscode, opt => opt.MapFrom(s => SharedMappingFuncs.GetApplicationStatus(s.ApplicationStatusEnum)))
+            .ForMember(d => d.spd_applicationid, opt => opt.MapFrom(s => s.ControllingMemberCrcAppId ?? Guid.NewGuid()))
+            .IncludeBase<LicenceApplication, spd_application>();
+
+        _ = CreateMap<SaveControllingMemberCrcAppCmd, contact>()
+          .IncludeBase<LicenceApplication, contact>();
 
         _ = CreateMap<AliasResp, spd_alias>()
           .ForMember(d => d.spd_firstname, opt => opt.MapFrom(s => s.GivenName))

--- a/src/Spd.Resource.Repository/ControllingMemberCrcApplication/Mappings.cs
+++ b/src/Spd.Resource.Repository/ControllingMemberCrcApplication/Mappings.cs
@@ -131,10 +131,10 @@ internal class Mappings : Profile
         _ = CreateMap<SaveControllingMemberCrcAppCmd, spd_application>()
             .ForMember(d => d.statuscode, opt => opt.MapFrom(s => SharedMappingFuncs.GetApplicationStatus(s.ApplicationStatusEnum)))
             .ForMember(d => d.spd_applicationid, opt => opt.MapFrom(s => s.ControllingMemberCrcAppId ?? Guid.NewGuid()))
-            .IncludeBase<LicenceApplication, spd_application>();
+            .IncludeBase<ControllingMemberCrcApplication, spd_application>();
 
         _ = CreateMap<SaveControllingMemberCrcAppCmd, contact>()
-          .IncludeBase<LicenceApplication, contact>();
+          .IncludeBase<ControllingMemberCrcApplication, contact>();
 
         _ = CreateMap<AliasResp, spd_alias>()
           .ForMember(d => d.spd_firstname, opt => opt.MapFrom(s => s.GivenName))

--- a/src/Spd.Resource.Repository/PersonLicApplication/PersonLicApplicationRepository.cs
+++ b/src/Spd.Resource.Repository/PersonLicApplication/PersonLicApplicationRepository.cs
@@ -58,7 +58,7 @@ internal class PersonLicApplicationRepository : IPersonLicApplicationRepository
             }
         }
         _context.SetLink(app, nameof(app.spd_ApplicantId_contact), contact);
-        await LinkTeam(DynamicsConstants.Licensing_Client_Service_Team_Guid, app, ct);
+        SharedRepositoryFuncs.LinkTeam(_context, DynamicsConstants.Licensing_Client_Service_Team_Guid, app);
         await _context.SaveChangesAsync(ct);
         //Associate of 1:N navigation property with Create of Update is not supported in CRM, so have to save first.
         //then update category.
@@ -101,7 +101,7 @@ internal class PersonLicApplicationRepository : IPersonLicApplicationRepository
         else
             _context.SetLink(app, nameof(app.spd_CurrentExpiredLicenceId), null);
 
-        await LinkTeam(DynamicsConstants.Licensing_Client_Service_Team_Guid, app, ct);
+        SharedRepositoryFuncs.LinkTeam(_context,DynamicsConstants.Licensing_Client_Service_Team_Guid, app);
         await _context.SaveChangesAsync();
         //Associate of 1:N navigation property with Create of Update is not supported in CRM, so have to save first.
         //then update category.
@@ -156,12 +156,7 @@ internal class PersonLicApplicationRepository : IPersonLicApplicationRepository
         return new LicenceApplicationCmdResp((Guid)swlApp.spd_applicationid, swlApp._spd_applicantid_value, swlApp._spd_organizationid_value);
     }
 
-    private async Task LinkTeam(string teamGuidStr, spd_application app, CancellationToken ct)
-    {
-        Guid teamGuid = Guid.Parse(teamGuidStr);
-        team? serviceTeam = await _context.teams.Where(t => t.teamid == teamGuid).FirstOrDefaultAsync(ct);
-        _context.SetLink(app, nameof(spd_application.ownerid), serviceTeam);
-    }
+   
 
     private List<spd_alias>? GetAliases(Guid contactId)
     {

--- a/src/Spd.Resource.Repository/SharedRepositoryFuncs.cs
+++ b/src/Spd.Resource.Repository/SharedRepositoryFuncs.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Dynamics.CRM;
+using Polly;
 using Spd.Resource.Repository.PersonLicApplication;
 using Spd.Utilities.Dynamics;
 
@@ -44,5 +45,11 @@ internal static class SharedRepositoryFuncs
         {
             _context.SetLink(app, nameof(spd_application.spd_CurrentExpiredLicenceId), licence);
         }
+    }
+    public static void LinkTeam(DynamicsContext _context, string teamGuidStr, spd_application app)
+    {
+        Guid teamGuid = Guid.Parse(teamGuidStr);
+        team? serviceTeam =  _context.teams.Where(t => t.teamid == teamGuid).FirstOrDefault();
+        _context.SetLink(app, nameof(spd_application.ownerid), serviceTeam);
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- added auth save controller
- added manager for controlling member crc app auth save
- added repository for auth save controlling member crc app
- mappings for auth save controlling member crc app
- moved `LinkTeam` to `SharedRepositoryFuncs` and related changes.
- assigned `WorkerLicenceTypeCode` to controlling memeber crc enum option.