### PR TITLE
support unauth sp abort biz app

### DIFF
--- a/src/Spd.Presentation.Licensing/Controllers/BizLicensingController.cs
+++ b/src/Spd.Presentation.Licensing/Controllers/BizLicensingController.cs
@@ -1,7 +1,3 @@
-using System.ComponentModel.DataAnnotations;
-using System.Net;
-using System.Security.Principal;
-using System.Text.Json;
 using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -12,6 +8,10 @@ using Spd.Manager.Licence;
 using Spd.Manager.Shared;
 using Spd.Utilities.Recaptcha;
 using Spd.Utilities.Shared.Exceptions;
+using System.ComponentModel.DataAnnotations;
+using System.Net;
+using System.Security.Principal;
+using System.Text.Json;
 
 namespace Spd.Presentation.Licensing.Controllers
 {
@@ -216,7 +216,11 @@ namespace Spd.Presentation.Licensing.Controllers
             if (!validateResult.IsValid)
                 throw new ApiException(HttpStatusCode.BadRequest, JsonSerializer.Serialize(validateResult.Errors));
 
-            return await _mediator.Send(new BizLicAppSubmitCommand(bizUpsertRequest), ct);
+            var response = await _mediator.Send(new BizLicAppSubmitCommand(bizUpsertRequest), ct);
+
+            //clear the cookie for the sole proprietor swl
+            SetValueToResponseCookie(SessionConstants.AnonymousSoleProprietorApplicationContext, string.Empty);
+            return response;
         }
 
         /// <summary>

--- a/src/Spd.Presentation.Licensing/Controllers/SecurityWorkerLicensingController.cs
+++ b/src/Spd.Presentation.Licensing/Controllers/SecurityWorkerLicensingController.cs
@@ -316,7 +316,7 @@ namespace Spd.Presentation.Licensing.Controllers
             SetValueToResponseCookie(SessionConstants.AnonymousApplicationContext, String.Empty);
 
             //if it is sole proprietor, we have to support connect two flows together and we have to support user abort the second flow, user can still go back to the first flow.
-            if (response.LicenceAppId != null && (jsonRequest.BizTypeCode == BizTypeCode.NonRegisteredSoleProprietor || jsonRequest.BizTypeCode == BizTypeCode.RegisteredSoleProprietor))
+            if (response?.LicenceAppId != null && (jsonRequest.BizTypeCode == BizTypeCode.NonRegisteredSoleProprietor || jsonRequest.BizTypeCode == BizTypeCode.RegisteredSoleProprietor))
             {
                 SetValueToResponseCookie(SessionConstants.AnonymousSoleProprietorApplicationContext, response.LicenceAppId.ToString(), 180);
             }

--- a/src/Spd.Presentation.Licensing/Controllers/SessionConstants.cs
+++ b/src/Spd.Presentation.Licensing/Controllers/SessionConstants.cs
@@ -3,6 +3,7 @@
 public static class SessionConstants
 {
     public static readonly string AnonymousRequestDataProtectorName = "AppAnonymousSubmitRequest";
-    public static readonly string AnonymousApplicationContext = "LicenceApplicationContext";
+    public static readonly string AnonymousApplicationContext = "LicenceApplicationContext"; //used for anonymous update/renew/replace, get application content
     public static readonly string AnonymousApplicationSubmitKeyCode = "LicenceApplicationSubmitKeyCode";
+    public static readonly string AnonymousSoleProprietorApplicationContext = "SoleProprietorApplicationContext"; //used for unauth sole proprietor, biz abort the app
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- This is to support unauth sp app, biz go back to swl flow, we need to save the licenceApp in the cookie to ensure it is one session.
