### PR TITLE
return jobId in http response header for licence preview endpoint

### DIFF
--- a/src/Spd.Manager.Printing/Contract.cs
+++ b/src/Spd.Manager.Printing/Contract.cs
@@ -35,4 +35,4 @@ public enum JobStatusCode
     Fail //Inactive State status reason
 }
 
-public record PreviewDocumentResp(string ContentType, IEnumerable<byte> Content);
+public record PreviewDocumentResp(string ContentType, IEnumerable<byte> Content, string JobId);

--- a/src/Spd.Manager.Printing/PrintingManager.cs
+++ b/src/Spd.Manager.Printing/PrintingManager.cs
@@ -158,7 +158,7 @@ internal class PrintingManager
     {
         var previewResponse = await _printer.Preview(new BCMailPlusPrintRequest(bcmailplusResponse.JobTemplateId, bcmailplusResponse.Document), cancellationToken);
         if (previewResponse.Status != JobStatus.Completed) throw new InvalidOperationException(previewResponse.Error);
-        return new PreviewDocumentResp(previewResponse.ContentType!, previewResponse.Content!);
+        return new PreviewDocumentResp(previewResponse.ContentType!, previewResponse.Content!, previewResponse.PrintJobId);
     }
 
 }

--- a/src/Spd.Presentation.Dynamics/Controllers/PrintingController.cs
+++ b/src/Spd.Presentation.Dynamics/Controllers/PrintingController.cs
@@ -28,6 +28,7 @@ public class PrintingController(IMediator mediator, IMapper mapper) : SpdControl
 
     /// <summary>
     /// return the preview picture of licence.
+    /// The bcmp job id will be returned in the http header as "bcmp-personal-licence-preview-jobid"
     /// </summary>
     /// <param name="eventId"></param>
     /// <param name="ct"></param>

--- a/src/Spd.Presentation.Dynamics/Controllers/PrintingController.cs
+++ b/src/Spd.Presentation.Dynamics/Controllers/PrintingController.cs
@@ -36,6 +36,7 @@ public class PrintingController(IMediator mediator, IMapper mapper) : SpdControl
     public async Task<Results<FileContentHttpResult, BadRequest>> GetPersonLicencePreview([FromRoute] Guid licenceId, CancellationToken ct)
     {
         var previewResponse = await mediator.Send(new PreviewDocumentCommand(licenceId), ct);
+        Response.Headers.Append("bcmp-personal-licence-preview-jobid", previewResponse.JobId);
         return TypedResults.File(previewResponse.Content.ToArray(), previewResponse.ContentType);
     }
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

-spdbt-2610(Return the JobId in BCMP preview endpoint response header)