### PR TITLE
[SPDBT-3113] throwing exception when licence category not found

### DIFF
--- a/src/Spd.Resource.Repository/SharedRepositoryFuncs.cs
+++ b/src/Spd.Resource.Repository/SharedRepositoryFuncs.cs
@@ -11,7 +11,10 @@ internal static class SharedRepositoryFuncs
         foreach (var c in categories)
         {
             var cat = _context.LookupLicenceCategory(c.ToString());
-            if (cat != null && !app.spd_application_spd_licencecategory.Any(c => c.spd_licencecategoryid == cat.spd_licencecategoryid))
+            if (cat == null)
+                throw new ArgumentException($"licence category not found for {c.ToString()}");
+
+            if (!app.spd_application_spd_licencecategory.Any(c => c.spd_licencecategoryid == cat.spd_licencecategoryid))
             {
                 _context.AddLink(app, nameof(spd_application.spd_application_spd_licencecategory), cat);
             }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

a solution for SPDBT-3113, we can prevent proceeding app and throw exception, then the app will save with portal status `Draft `and reason `Incomplete`,
currently, however it does not find one category, it proceeds, and app is saved with portal status `Awaiting Payment` and reason `Payment Pending`