### PR TITLE
[SPDBT-3171] When deleting some org user, "value cannot be Null" exception is thrown

### DIFF
--- a/src/Spd.Resource.Repository/User/OrgUserRepository.cs
+++ b/src/Spd.Resource.Repository/User/OrgUserRepository.cs
@@ -227,7 +227,8 @@ namespace Spd.Resource.Repository.User
             else
             {
                 var invition = GetPortalInvitationByUserId(userId);
-                _dynaContext.DeleteObject(invition);
+                if (invition != null)
+                    _dynaContext.DeleteObject(invition);
 
                 // Delete user and invitation
                 _dynaContext.DeleteObject(user);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [SPDBT-3171] When deleting some org user, "value cannot be Null" exception is thrown
