### PR TITLE
return response instead of throw bad request for anonymous licence search

### DIFF
--- a/src/Spd.Presentation.Licensing/Controllers/LicenceController.cs
+++ b/src/Spd.Presentation.Licensing/Controllers/LicenceController.cs
@@ -92,7 +92,8 @@ namespace Spd.Presentation.Licensing.Controllers
             if (response?.ServiceTypeCode == ServiceTypeCode.SecurityWorkerLicence)
                 latestAppId = await _mediator.Send(new GetLatestWorkerLicenceApplicationIdQuery((Guid)response.LicenceHolderId));
             else if (response?.ServiceTypeCode == ServiceTypeCode.SecurityBusinessLicence)
-                throw new ApiException(HttpStatusCode.BadRequest, "Biz licensing does not support anonymous.");
+                return response;
+            //throw new ApiException(HttpStatusCode.BadRequest, "Biz licensing does not support anonymous.");
             else if (response != null)
                 latestAppId = await _mediator.Send(new GetLatestPermitApplicationIdQuery((Guid)response.LicenceHolderId, (ServiceTypeCode)response.ServiceTypeCode));
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

-return response instead of throw bad request.
