### PR TITLE
[SPDBT-3543] fix sonar-cube: 'response' is null on at least one execution path.

### DIFF
--- a/src/Spd.Manager.Licence/SecurityWorkerAppManager.cs
+++ b/src/Spd.Manager.Licence/SecurityWorkerAppManager.cs
@@ -263,6 +263,9 @@ internal class SecurityWorkerAppManager :
                 null,
                 cancellationToken);
 
+        if (response == null)
+            throw new ApiException(HttpStatusCode.InternalServerError, "Create security worker licence application failed.");
+
         //copying all old files to new application in PreviousFileIds 
         if (cmd.LicenceAnonymousRequest.PreviousDocumentIds != null && cmd.LicenceAnonymousRequest.PreviousDocumentIds.Any())
         {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [SPDBT-3543] fix sonar-cube: 'response' is null on at least one execution path.
