### PR TITLE
SPDBT-3917: Current/Expired Licence is not showing in SPARC application when applicant is submitting new application

### DIFF
--- a/src/Spd.Resource.Repository/PersonLicApplication/PersonLicApplicationRepository.cs
+++ b/src/Spd.Resource.Repository/PersonLicApplication/PersonLicApplicationRepository.cs
@@ -31,6 +31,11 @@ internal class PersonLicApplicationRepository : IPersonLicApplicationRepository
         {
             //spdbt-3402: for unauth, always create new contact
             contact = await _context.CreateContact(contact, null, _mapper.Map<IEnumerable<spd_alias>>(cmd.Aliases), ct);
+            if (cmd.HasExpiredLicence == true && cmd.ExpiredLicenceId != null)
+                SharedRepositoryFuncs.LinkLicence(_context, cmd.ExpiredLicenceId, app);
+            else
+                _context.SetLink(app, nameof(app.spd_CurrentExpiredLicenceId), null);
+
         }
         else
         {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- fix 3917(Current/Expired Licence is not showing in SPARC application when applicant is submitting new application)
