### PR TITLE
[SPDBT-4074] Return 200 with empty response body for getting licence photo

### DIFF
--- a/src/Spd.Manager.Licence/LicenceManager.cs
+++ b/src/Spd.Manager.Licence/LicenceManager.cs
@@ -128,7 +128,7 @@ internal class LicenceManager :
             throw new ApiException(HttpStatusCode.BadRequest, "cannot find the licence.");
         }
         if (lic.PhotoDocumentUrlId == null)
-            throw new ApiException(HttpStatusCode.BadRequest, "the licence does not have photo");
+            return new FileResponse();
 
         DocumentResp? docUrl = await _documentRepository.GetAsync((Guid)lic.PhotoDocumentUrlId, cancellationToken);
         if (docUrl == null)


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [SPDBT-4074] Return 200 with empty response body for getting licence photo
