### PR TITLE
Release/2.0.0 hotfix2-dog restraints, get documents throws Exception when document url tag is null

### DIFF
--- a/src/Spd.Resource.Repository/Document/DocumentRepository.cs
+++ b/src/Spd.Resource.Repository/Document/DocumentRepository.cs
@@ -121,7 +121,7 @@ internal class DocumentRepository : IDocumentRepository
             else if (doc?.ApplicationId != null)
                 return resp.Where(i => i.ApplicationId == doc.ApplicationId).ToList();
             else
-                return resp.Where(i => i.CreatedOn == doc.CreatedOn).ToList();
+                return resp.Where(i => i.CreatedOn == doc?.CreatedOn).ToList();
             //else
             //    return resp.Where(i => i.UploadedDateTime == doc.UploadedDateTime).ToList();
         }

--- a/src/Spd.Resource.Repository/Document/DocumentRepository.cs
+++ b/src/Spd.Resource.Repository/Document/DocumentRepository.cs
@@ -71,7 +71,8 @@ internal class DocumentRepository : IDocumentRepository
         if (qry.MultiFileTypes != null)
         {
             List<Guid> tagIds = qry.MultiFileTypes.Select(f => DynamicsContextLookupHelpers.BcGovTagDictionary.GetValueOrDefault(f.ToString())).ToList();
-            List<bcgov_documenturl> result = results.Where(d => tagIds.Contains(d._bcgov_tag1id_value.Value)).ToList();
+            List<bcgov_documenturl> result = results
+                .Where(d => d._bcgov_tag1id_value.HasValue && tagIds.Contains(d._bcgov_tag1id_value.Value)).ToList();
             resp = _mapper.Map<IEnumerable<DocumentResp>>(result.OrderByDescending(a => a.createdon));
         }
         else


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Release/2.0.0 hotfix2-dog restraints, get documents throws Exception when document url tag is null
