### PR TITLE
[SPDBT-4376] Screening [PROD] - Deactivate the Portal User Invitation when after Identity is created for Portal User

### DIFF
--- a/src/Spd.Presentation.Licensing/Controllers/LicenceController.cs
+++ b/src/Spd.Presentation.Licensing/Controllers/LicenceController.cs
@@ -248,7 +248,7 @@ namespace Spd.Presentation.Licensing.Controllers
             //spdbt-4396
             //The pattern matches strings that:
             //Start with E
-            //Are followed by 4–6 digits
+            //Are followed by 4-6 digits
             //And may optionally end with ST or st(case -insensitive)
             //The string may have any characters as separators, and the matching should be case-insensitive for the suffix.
             var pattern = @"E\d{4,6}(?:st)?";

--- a/src/Spd.Resource.Repository/PortalUser/PortalUserRepository.cs
+++ b/src/Spd.Resource.Repository/PortalUser/PortalUserRepository.cs
@@ -106,6 +106,8 @@ internal class PortalUserRepository : IPortalUserRepository
 
         //set invite views
         invite.spd_views = (invite.spd_views ?? 0) + 1;
+        invite.statecode = DynamicsConstants.StateCode_Inactive;
+        invite.statuscode = (int)Enum.Parse<InvitationStatus>(ApplicationInviteStatusEnum.Completed.ToString());
         _context.UpdateObject(invite);
 
         await _context.SaveChangesAsync(ct);

--- a/src/Spd.Resource.Repository/User/OrgUserRepository.cs
+++ b/src/Spd.Resource.Repository/User/OrgUserRepository.cs
@@ -108,6 +108,8 @@ namespace Spd.Resource.Repository.User
 
             //set invite views
             invite.spd_views = (invite.spd_views ?? 0) + 1;
+            invite.statecode = DynamicsConstants.StateCode_Inactive;
+            invite.statuscode = (int)Enum.Parse<InvitationStatus>(ApplicationInviteStatusEnum.Completed.ToString());
             _dynaContext.UpdateObject(invite);
 
             await _dynaContext.SaveChangesAsync(ct);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [SPDBT-4376] Screening [PROD] - Deactivate the Portal User Invitation when after Identity is created for Portal User
- For Biz Licensing - portal administrator, we did the same, deactivate intivation after user login.
