### PR TITLE
 SPDBT # 4642 Licensing - New/Expired License Lookup to Include Suspended/Cancelled

### DIFF
--- a/src/Spd.Manager.Licence/LicenceManager.cs
+++ b/src/Spd.Manager.Licence/LicenceManager.cs
@@ -83,7 +83,8 @@ internal class LicenceManager :
             return null;
         }
         LicenceResp? response = qryResponse.Items
-            .Where(i => i.LicenceStatusCode == LicenceStatusEnum.Active || i.LicenceStatusCode == LicenceStatusEnum.Expired)
+            .Where(i => i.LicenceStatusCode == LicenceStatusEnum.Active || i.LicenceStatusCode == LicenceStatusEnum.Expired
+             || i.LicenceStatusCode == LicenceStatusEnum.Suspended || i.LicenceStatusCode == LicenceStatusEnum.Cancelled)
             .OrderByDescending(i => i.CreatedOn)
             .FirstOrDefault();
         if (response == null) { return null; }

--- a/src/Spd.Manager.Shared/Contract.cs
+++ b/src/Spd.Manager.Shared/Contract.cs
@@ -180,7 +180,8 @@ namespace Spd.Manager.Shared
         Inactive,
         Expired,
         Suspended,
-        Preview
+        Preview,
+        Cancelled
     }
 
     public enum PortalUserServiceCategoryCode

--- a/src/Spd.Presentation.GuideDogServiceDog/ClientApp/src/app/components/dog-trainer/step-dt-checklist-new.component.ts
+++ b/src/Spd.Presentation.GuideDogServiceDog/ClientApp/src/app/components/dog-trainer/step-dt-checklist-new.component.ts
@@ -11,7 +11,7 @@ import { SPD_CONSTANTS } from '@app/core/constants/constants';
 						Please note: The registrar will <b>not</b> issue or renew a dog trainer certificate unless the individual
 						identified in the application trains dogs on behalf of an accredited training school for the purpose of the
 						dogs becoming guide dogs or service dogs. <br>
-						<b>Dog trainer applications are submitted by accredited training schools.</b> 
+						<b>Dog trainer applications must be submitted by accredited training schools.</b> 
 					</p>
 						
 

--- a/src/Spd.Presentation.GuideDogServiceDog/ClientApp/src/app/components/dog-trainer/step-dt-checklist-renewal.component.ts
+++ b/src/Spd.Presentation.GuideDogServiceDog/ClientApp/src/app/components/dog-trainer/step-dt-checklist-renewal.component.ts
@@ -11,7 +11,7 @@ import { SPD_CONSTANTS } from '@app/core/constants/constants';
 						Please note: The registrar will <b>not</b> issue or renew a dog trainer certificate unless the individual
 						identified in the application trains dogs on behalf of an accredited training school for the purpose of the
 						dogs becoming guide dogs or service dogs. <br>
-						<b>Dog trainer applications are submitted by accredited training schools.</b>
+						<b>Dog trainer applications must be submitted by accredited training schools.</b>
 					</p>
 
 					<div class="fw-semibold fs-6 mb-2">For all applicants:</div>

--- a/src/Spd.Presentation.Licensing/ClientApp/src/app/api/models/licence-status-code.ts
+++ b/src/Spd.Presentation.Licensing/ClientApp/src/app/api/models/licence-status-code.ts
@@ -7,5 +7,6 @@ export enum LicenceStatusCode {
   Inactive = 'Inactive',
   Expired = 'Expired',
   Suspended = 'Suspended',
-  Preview = 'Preview'
+  Preview = 'Preview',
+  Cancelled = 'Cancelled'
 }

--- a/src/Spd.Resource.Repository/Licence/Contract.cs
+++ b/src/Spd.Resource.Repository/Licence/Contract.cs
@@ -123,6 +123,7 @@ namespace Spd.Resource.Repository.Licence
         Inactive,
         Expired,
         Suspended,
-        Preview
+        Preview, 
+        Cancelled
     }
 }

--- a/src/Spd.Resource.Repository/Licence/LicenceRepository.cs
+++ b/src/Spd.Resource.Repository/Licence/LicenceRepository.cs
@@ -78,7 +78,7 @@ internal class LicenceRepository : ILicenceRepository
             lics = lics.Where(d => d.statecode != DynamicsConstants.StateCode_Inactive);
 
         if (qry.IncludeInactive)
-            lics = lics.Where(d => d.statuscode != (int)LicenceStatusOptionSet.Inactive && d.statuscode != (int)LicenceStatusOptionSet.Suspended && d.statuscode != (int)LicenceStatusOptionSet.Cancelled);
+            lics = lics.Where(d => d.statuscode != (int)LicenceStatusOptionSet.Inactive);
 
         if (qry.LicenceId != null)
         {


### PR DESCRIPTION
# Description

SPDBT # 4642 Licensing - New/Expired License Lookup to Include Suspended/Cancelled
Updated the licence manager handle method to include the cancelled and suspended licences
Added Cancelled LicenceStatusCode enum
Updated the Licency query not to include the inactive but not cancelled and suspended
Generated Frontend services after the model changes

- {List all the changes, if possible add the jira ticket #}
