### PR TITLE
SPDBT # 4644 Licensing - Portal Document Validation

### DIFF
--- a/src/Spd.Manager.Licence/SecurityWorkerAppContract.cs
+++ b/src/Spd.Manager.Licence/SecurityWorkerAppContract.cs
@@ -21,7 +21,7 @@ public record WorkerLicenceSubmitCommand(WorkerLicenceAppUpsertRequest LicenceUp
 
 public record WorkerLicenceAppNewCommand(
     WorkerLicenceAppSubmitRequest LicenceAnonymousRequest,
-    IEnumerable<LicAppFileInfo> LicAppFileInfos)
+    IEnumerable<LicAppFileInfo> LicAppFileInfos, IEnumerable<DocumentRelatedInfo> DocumentRelatedInfos)
     : IRequest<WorkerLicenceCommandResponse>;
 
 public record WorkerLicenceAppReplaceCommand(

--- a/src/Spd.Manager.Licence/SecurityWorkerAppManager.cs
+++ b/src/Spd.Manager.Licence/SecurityWorkerAppManager.cs
@@ -510,6 +510,7 @@ internal class SecurityWorkerAppManager :
     {
         WorkerLicenceAppSubmitRequest request = cmd.LicenceAnonymousRequest;
         IEnumerable<LicAppFileInfo> fileInfos = cmd.LicAppFileInfos;
+        
         if (request.IsPoliceOrPeaceOfficer == true &&
             !fileInfos.Any(f => f.LicenceDocumentTypeCode == LicenceDocumentTypeCode.PoliceBackgroundLetterOfNoConflict))
         {
@@ -548,11 +549,30 @@ internal class SecurityWorkerAppManager :
         {
             if (!LicenceAppDocumentManager.WorkerCategoryTypeCode_NoNeedDocument.Contains(code))
             {
-                if (!fileInfos.Any(f => Mappings.GetDocumentType2Enum(f.LicenceDocumentTypeCode) == Enum.Parse<DocumentTypeEnum>(code.ToString())))
+                // Standard match: any uploaded file that maps to the DocumentTypeEnum for this category
+                bool hasMatchingDocument = fileInfos.Any(f =>
+                    Mappings.GetDocumentType2Enum(f.LicenceDocumentTypeCode) ==
+                    Enum.Parse<DocumentTypeEnum>(code.ToString()));
+
+                // Special case: SecurityGuard can be satisfied by the "no certificate" document code
+                if (!hasMatchingDocument && code == WorkerCategoryTypeCode.SecurityGuard)
+                {
+                    hasMatchingDocument = cmd.DocumentRelatedInfos.Any(f =>
+                        f.LicenceDocumentTypeCode == LicenceDocumentTypeCode.CategorySecurityGuard_BasicSecurityTrainingNoCertificate);
+                }
+
+                if (!hasMatchingDocument)
                 {
                     throw new ApiException(HttpStatusCode.BadRequest, $"Missing file for {code}");
                 }
             }
+            //if (!LicenceAppDocumentManager.WorkerCategoryTypeCode_NoNeedDocument.Contains(code))
+            //{
+            //    if (!fileInfos.Any(f => Mappings.GetDocumentType2Enum(f.LicenceDocumentTypeCode) == Enum.Parse<DocumentTypeEnum>(code.ToString())))
+            //    {
+            //        throw new ApiException(HttpStatusCode.BadRequest, $"Missing file for {code}");
+            //    }
+            //}
         }
     }
 

--- a/src/Spd.Presentation.Licensing/ClientApp/src/app/core/services/worker-application.helper.ts
+++ b/src/Spd.Presentation.Licensing/ClientApp/src/app/core/services/worker-application.helper.ts
@@ -21,6 +21,7 @@ import { ConfigService } from 'src/app/core/services/config.service';
 import { FormControlValidators } from 'src/app/core/validators/form-control.validators';
 import { FormGroupValidators } from 'src/app/core/validators/form-group.validators';
 import { CommonApplicationHelper } from './common-application.helper';
+import { D } from 'node_modules/@angular/cdk/bidi-module.d-IN1Vp56w';
 
 export abstract class WorkerApplicationHelper extends CommonApplicationHelper {
 	securityGuardRequirementCodes = SecurityGuardRequirementCode;
@@ -1077,6 +1078,15 @@ export abstract class WorkerApplicationHelper extends CommonApplicationHelper {
 		restraintsAuthorizationData: any
 	): Array<Document> {
 		const documents: Array<Document> = [];
+
+		if(categorySecurityGuardData.requirementCode === LicenceDocumentTypeCode.CategorySecurityGuardBasicSecurityTrainingNoCertificate) {
+			// Add document record for BasicSecurityTrainingNoCertificate (no actual file required)
+			documents.push({
+				documentIdNumber: '',
+				expiryDate: new Date().toISOString().split('T')[0],
+				licenceDocumentTypeCode: categorySecurityGuardData.requirementCode,
+			});
+		}
 
 		categorySecurityGuardData.attachments?.forEach((doc: any) => {
 			documents.push({

--- a/src/Spd.Presentation.Licensing/Controllers/SecurityWorkerLicensingController.cs
+++ b/src/Spd.Presentation.Licensing/Controllers/SecurityWorkerLicensingController.cs
@@ -213,7 +213,7 @@ namespace Spd.Presentation.Licensing.Controllers
             WorkerLicenceCommandResponse? response = null;
             if (jsonRequest.ApplicationTypeCode == ApplicationTypeCode.New)
             {
-                WorkerLicenceAppNewCommand command = new(jsonRequest, newDocInfos);
+                WorkerLicenceAppNewCommand command = new(jsonRequest, newDocInfos, jsonRequest.DocumentRelatedInfos);
                 response = await _mediator.Send(command, ct);
             }
 


### PR DESCRIPTION
Added new parameter to get the DocumentRelatedInfo files 
Updated the WorkerLicenceAppNewCommand to get the new parameter 
Updated logic to validate the new case where the document is not attached Added logic on the getCategorySecurityGuard method to push the licence category with No code

# Description

This PR includes the following proposed change(s):

- {List all the changes, if possible add the jira ticket #}
