### PR TITLE
SPDBT # 4667 Licensing & Screening: Wrong Phone Number on Error Message

### DIFF
--- a/src/Spd.Presentation.GuideDogServiceDog/ClientApp/src/app/shared/components/dialog-oops.component.ts
+++ b/src/Spd.Presentation.GuideDogServiceDog/ClientApp/src/app/shared/components/dialog-oops.component.ts
@@ -23,8 +23,8 @@ export interface DialogOopsOptions {
 		       <h2 class="mt-2">Oops! Something went wrong</h2>
 		      <p>Looks like something went wrong on our end. Please try again or contact:</p>
 			  <ul>
-  				<li><b>CRRP - </b><a href="mailto:criminalrecords&#64;gov.bc.ca">criminalrecords&#64;gov.bc.ca</a> or 1-855-587-0182 (Option 2) </li>
- 				<li><b>SSLU - </b><a href="mailto:securitylicensing&#64;gov.bc.ca">securitylicensing&#64;gov.bc.ca</a> or 1-855-587-0182 (Option 1) </li>
+  				<li><b>CRRP - </b><a href="mailto:criminalrecords&#64;gov.bc.ca">criminalrecords&#64;gov.bc.ca</a> or 1-855-587-0185 (Option 2) </li>
+ 				<li><b>SSLU - </b><a href="mailto:securitylicensing&#64;gov.bc.ca">securitylicensing&#64;gov.bc.ca</a> or 1-855-587-0185 (Option 1) </li>
 			  </ul> 
 		    }
 		

--- a/src/Spd.Presentation.Licensing/ClientApp/src/app/shared/components/dialog-oops.component.ts
+++ b/src/Spd.Presentation.Licensing/ClientApp/src/app/shared/components/dialog-oops.component.ts
@@ -23,8 +23,8 @@ export interface DialogOopsOptions {
 			  <h2 class="mt-2">Oops! Something went wrong</h2>
 		      <p>Looks like something went wrong on our end. Please try again or contact:</p>
 			  <ul>
-  				<li><b>CRRP - </b><a href="mailto:criminalrecords&#64;gov.bc.ca">criminalrecords&#64;gov.bc.ca</a> or 1-855-587-0182 (Option 2) </li>
- 				<li><b>SSLU - </b><a href="mailto:securitylicensing&#64;gov.bc.ca">securitylicensing&#64;gov.bc.ca</a> or 1-855-587-0182 (Option 1) </li>
+  				<li><b>CRRP - </b><a href="mailto:criminalrecords&#64;gov.bc.ca">criminalrecords&#64;gov.bc.ca</a> or 1-855-587-0185 (Option 2) </li>
+ 				<li><b>SSLU - </b><a href="mailto:securitylicensing&#64;gov.bc.ca">securitylicensing&#64;gov.bc.ca</a> or 1-855-587-0185 (Option 1) </li>
 			  </ul> 
 			}
 

--- a/src/Spd.Presentation.Screening/ClientApp/src/app/shared/components/dialog-oops.component.ts
+++ b/src/Spd.Presentation.Screening/ClientApp/src/app/shared/components/dialog-oops.component.ts
@@ -23,8 +23,8 @@ export interface DialogOopsOptions {
 		      <h2 class="mt-2">Oops! Something went wrong</h2>
 		      <p>Looks like something went wrong on our end. Please try again or contact:</p>
 			  <ul>
-  				<li><b>CRRP - </b><a href="mailto:criminalrecords&#64;gov.bc.ca">criminalrecords&#64;gov.bc.ca</a> or 1-855-587-0182 (Option 2) </li>
- 				<li><b>SSLU - </b><a href="mailto:securitylicensing&#64;gov.bc.ca">securitylicensing&#64;gov.bc.ca</a> or 1-855-587-0182 (Option 1) </li>
+  				<li><b>CRRP - </b><a href="mailto:criminalrecords&#64;gov.bc.ca">criminalrecords&#64;gov.bc.ca</a> or 1-855-587-0185 (Option 2) </li>
+ 				<li><b>SSLU - </b><a href="mailto:securitylicensing&#64;gov.bc.ca">securitylicensing&#64;gov.bc.ca</a> or 1-855-587-0185 (Option 1) </li>
 			  </ul> 
 				
 		    }


### PR DESCRIPTION
# Description

SPDBT # 4667 Licensing & Screening: Wrong Phone Number on Error Message
_ Fixed the phone number on the SPD Guide dog dialog
- Fixed the phone number on the Spd Licensing and SPD Screening applications 


